### PR TITLE
Refactor/TerminalBuffer

### DIFF
--- a/terminal-emulator/src/main/java/com/termux/terminal/BufferStyler.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/BufferStyler.java
@@ -1,0 +1,45 @@
+package com.termux.terminal;
+
+public class BufferStyler {
+
+    TerminalBuffer mTerminalBuffer;
+
+    public BufferStyler(TerminalBuffer terminalBuffer) {
+        mTerminalBuffer = terminalBuffer;
+    }
+
+    /** Support for http://vt100.net/docs/vt510-rm/DECCARA and http://vt100.net/docs/vt510-rm/DECCARA */
+    public void setOrClearEffect(int bits, boolean isSetOrClear, boolean isReverse, boolean isRectangular, int leftMargin, int rightMargin, int top, int left,
+                                 int bottom, int right) {
+        for (int row = top; row < bottom; row++) {
+            TerminalRow line = mTerminalBuffer.mLines[mTerminalBuffer.externalToInternalRow(row)];
+            int startOfLine = (isRectangular || row == top) ? left : leftMargin;
+            int endOfLine = (isRectangular || row + 1 == bottom) ? right : rightMargin;
+            for (int col = startOfLine; col < endOfLine; col++) {
+                setStyle(bits, isSetOrClear, isReverse, line, col);
+            }
+        }
+    }
+
+    private void setStyle(int bits, boolean isSetOrClear, boolean isReverse, TerminalRow line, int col) {
+        final long currentStyle = line.getStyle(col);
+        final int foreColor = TextStyle.decodeForeColor(currentStyle);
+        final int backColor = TextStyle.decodeBackColor(currentStyle);
+        int effect = getEffect(bits, isSetOrClear, isReverse, currentStyle);
+        line.mStyle[col] = TextStyle.encode(foreColor, backColor, effect);
+    }
+
+    private int getEffect(int bits, boolean isSetOrClear, boolean isReverse, long currentStyle) {
+        int effect = TextStyle.decodeEffect(currentStyle);
+        if (isReverse) {
+            // Clear out the bits to reverse and add them back in reversed:
+            effect = (effect & ~bits) | (bits & ~effect);
+        } else if (isSetOrClear) {
+            effect |= bits;
+        } else {
+            effect &= ~bits;
+        }
+        return effect;
+    }
+
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -237,44 +237,6 @@ public final class TerminalBuffer {
         allocateFullLineIfNecessary(row).setChar(column, codePoint, style);
     }
 
-    public long getStyleAt(int externalRow, int column) {
-        return allocateFullLineIfNecessary(externalToInternalRow(externalRow)).getStyle(column);
-    }
-
-    /** Support for http://vt100.net/docs/vt510-rm/DECCARA and http://vt100.net/docs/vt510-rm/DECCARA */
-    public void setOrClearEffect(int bits, boolean isSetOrClear, boolean isReverse, boolean isRectangular, int leftMargin, int rightMargin, int top, int left,
-                                 int bottom, int right) {
-        for (int row = top; row < bottom; row++) {
-            TerminalRow line = mLines[externalToInternalRow(row)];
-            int startOfLine = (isRectangular || row == top) ? left : leftMargin;
-            int endOfLine = (isRectangular || row + 1 == bottom) ? right : rightMargin;
-            for (int col = startOfLine; col < endOfLine; col++) {
-                setStyle(bits, isSetOrClear, isReverse, line, col);
-            }
-        }
-    }
-
-    private void setStyle(int bits, boolean isSetOrClear, boolean isReverse, TerminalRow line, int col) {
-        final long currentStyle = line.getStyle(col);
-        final int foreColor = TextStyle.decodeForeColor(currentStyle);
-        final int backColor = TextStyle.decodeBackColor(currentStyle);
-        int effect = getEffect(bits, isSetOrClear, isReverse, currentStyle);
-        line.mStyle[col] = TextStyle.encode(foreColor, backColor, effect);
-    }
-
-    private int getEffect(int bits, boolean isSetOrClear, boolean isReverse, long currentStyle) {
-        int effect = TextStyle.decodeEffect(currentStyle);
-        if (isReverse) {
-            // Clear out the bits to reverse and add them back in reversed:
-            effect = (effect & ~bits) | (bits & ~effect);
-        } else if (isSetOrClear) {
-            effect |= bits;
-        } else {
-            effect &= ~bits;
-        }
-        return effect;
-    }
-
     public void clearTranscript() {
         if (mScreenFirstRow < mActiveTranscriptRows) {
             Arrays.fill(mLines, mTotalRows + mScreenFirstRow - mActiveTranscriptRows, mTotalRows, null);
@@ -284,6 +246,17 @@ public final class TerminalBuffer {
         }
         mActiveTranscriptRows = 0;
     }
+
+    public long getStyleAt(int externalRow, int column) {
+        return allocateFullLineIfNecessary(externalToInternalRow(externalRow)).getStyle(column);
+    }
+
+    /** Support for http://vt100.net/docs/vt510-rm/DECCARA and http://vt100.net/docs/vt510-rm/DECCARA */
+    public void setOrClearEffect(int bits, boolean isSetOrClear, boolean isReverse, boolean isRectangular, int leftMargin, int rightMargin, int top, int left,
+                                 int bottom, int right) {
+        new BufferStyler(this).setOrClearEffect(bits, isSetOrClear, isReverse, isRectangular, leftMargin, rightMargin, top, left, bottom, right);
+    }
+
 
 }
 

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -62,7 +62,7 @@ public final class TerminalBuffer {
     }
 
     public String getWordAtLocation(int x, int y) {
-        return new TextFinder(this).getWordAtLocation(x, y);
+        return new TextFinder(this).getWordAtLocation(new Cursor(y, x));
     }
 
     public int getActiveTranscriptRows() {

--- a/terminal-emulator/src/main/java/com/termux/terminal/TextFinder.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TextFinder.java
@@ -80,17 +80,17 @@ public final class TextFinder {
         if (isBackLineRowNotWrapped && isFullLineNotFillsWidth && isRowBeforeSelY2) builder.append('\n');
     }
 
-    public String getWordAtLocation(int x, int y) {
+    public String getWordAtLocation(Cursor cursor) {
         // Set y1 and y2 to the lines where the wrapped line starts and ends.
         // I.e. if a line that is wrapped to 3 lines starts at line 4, and this
         // is called with y=5, then y1 would be set to 4 and y2 would be set to 6.
-        int y1 = lineWrapStarts(y);
-        int y2 = lineWrapEnds(y);
+        int y1 = lineWrapStarts(cursor.getRow());
+        int y2 = lineWrapEnds(cursor.getRow());
 
         // Get the text for the whole wrapped line
-        String text = getSelectedText(new Cursor(0, y1), new Cursor(mTerminalBuffer.mColumns, y2), true, true);
+        String text = getSelectedText(new Cursor(y1, 0), new Cursor(y2, mTerminalBuffer.mColumns), true, true);
         // The index of x in text
-        int textOffset = (y - y1) * mTerminalBuffer.mColumns + x;
+        int textOffset = (cursor.getRow() - y1) * mTerminalBuffer.mColumns + cursor.getColumn();
 
         if (textOffset >= text.length()) {
             // The click was to the right of the last word on the line, so


### PR DESCRIPTION
Set order of the variables properly in `getWordAtLocation()`.
Extract `setOrClearEffect()` to class`BufferStyler` satisfying Single responsibility principle.