### PR TITLE
Template Pattern/StringGenerator

### DIFF
--- a/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/LocalClientSocketStringGenerator.java
+++ b/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/LocalClientSocketStringGenerator.java
@@ -14,22 +14,19 @@ public class LocalClientSocketStringGenerator extends StringGenerator{
     }
 
     @Override
-    public String getLogString() {
-        StringBuilder logString = new StringBuilder();
-
+    public void appendLogHeader(StringBuilder logString) {
         logString.append("Client Socket:");
+    }
 
-        for (Pair<String, Object> logVar: getLogVariableList()) {
-            String label = logVar.first;
-            Object object = logVar.second;
-            logString.append("\n").append(Logger.getSingleLineLogStringEntry(label, object, "-"));
-        }
+    @Override
+    public boolean isLogMultiLine(String label) {
+        return false;
+    }
 
+    @Override
+    public void appendLogFooter(StringBuilder logString) {
         logString.append("\n\n\n");
-
         logString.append(mPeerCred.getLogString());
-
-        return logString.toString();
     }
 
     @Override

--- a/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/LocalClientSocketStringGenerator.java
+++ b/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/LocalClientSocketStringGenerator.java
@@ -30,21 +30,20 @@ public class LocalClientSocketStringGenerator extends StringGenerator{
     }
 
     @Override
-    public String getMarkdownString() {
-        StringBuilder markdownString = new StringBuilder();
-
+    public void appendMarkdownHeader(StringBuilder markdownString) {
         markdownString.append("## ").append("Client Socket");
+    }
 
-        for (Pair<String, Object> logVar: getLogVariableList()) {
-            String label = logVar.first;
-            Object object = logVar.second;
-            markdownString.append("\n").append(MarkdownUtils.getSingleLineMarkdownStringEntry(label, object, "-"));
-        }
+    @Override
+    public boolean isMarkdownMultiLine(String label) {
+        return label.equals("Cmdline");
+    }
 
+    @Override
+    public void appendMarkdownFooter(StringBuilder markdownString) {
         markdownString.append("\n\n\n");
-
         markdownString.append(mPeerCred.getMarkdownString());
 
-        return markdownString.toString();
     }
+
 }

--- a/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/LocalClientSocketStringGenerator.java
+++ b/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/LocalClientSocketStringGenerator.java
@@ -1,9 +1,5 @@
 package com.termux.shared.net.socket.local.StringGenerator;
 
-import android.util.Pair;
-
-import com.termux.shared.logger.Logger;
-import com.termux.shared.markdown.MarkdownUtils;
 import com.termux.shared.net.socket.local.PeerCred;
 
 public class LocalClientSocketStringGenerator extends StringGenerator{

--- a/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/LocalSocketRunConfigStringGenerator.java
+++ b/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/LocalSocketRunConfigStringGenerator.java
@@ -1,10 +1,5 @@
 package com.termux.shared.net.socket.local.StringGenerator;
 
-import android.util.Pair;
-
-import com.termux.shared.logger.Logger;
-import com.termux.shared.markdown.MarkdownUtils;
-
 public class LocalSocketRunConfigStringGenerator extends StringGenerator{
     private String mTitle;
 

--- a/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/LocalSocketRunConfigStringGenerator.java
+++ b/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/LocalSocketRunConfigStringGenerator.java
@@ -27,17 +27,17 @@ public class LocalSocketRunConfigStringGenerator extends StringGenerator{
     }
 
     @Override
-    public String getMarkdownString() {
-        StringBuilder markdownString = new StringBuilder();
-
+    public void appendMarkdownHeader(StringBuilder markdownString) {
         markdownString.append("## ").append(mTitle).append(" Socket Server Run Config");
-
-        for(Pair<String, Object> logVar: getLogVariableList()) {
-            String label = logVar.first;
-            Object object = logVar.second;
-            markdownString.append("\n").append(MarkdownUtils.getSingleLineMarkdownStringEntry(label, object, "-"));
-        }
-
-        return markdownString.toString();
     }
+
+    @Override
+    public boolean isMarkdownMultiLine(String label) {
+        return label.equals("Cmdline");
+    }
+
+    @Override
+    public void appendMarkdownFooter(StringBuilder markdownString) {
+    }
+
 }

--- a/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/LocalSocketRunConfigStringGenerator.java
+++ b/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/LocalSocketRunConfigStringGenerator.java
@@ -13,18 +13,17 @@ public class LocalSocketRunConfigStringGenerator extends StringGenerator{
     }
 
     @Override
-    public String getLogString() {
-        StringBuilder logString = new StringBuilder();
-
+    public void appendLogHeader(StringBuilder logString) {
         logString.append(mTitle).append(" Socket Server Run Config:");
+    }
 
-        for(Pair<String, Object> logVar: getLogVariableList()) {
-            String label = logVar.first;
-            Object object = logVar.second;
-            logString.append("\n").append(Logger.getSingleLineLogStringEntry(label, object, "-"));
-        }
+    @Override
+    public boolean isLogMultiLine(String label) {
+        return false;
+    }
 
-        return logString.toString();
+    @Override
+    public void appendLogFooter(StringBuilder logString) {
     }
 
     @Override

--- a/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/PeerCredStringGenerator.java
+++ b/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/PeerCredStringGenerator.java
@@ -23,23 +23,17 @@ public class PeerCredStringGenerator extends StringGenerator{
     }
 
     @Override
-    public String getMarkdownString() {
-        StringBuilder markdownString = new StringBuilder();
-
-        markdownString.append("## ").append("Peer Cred");
-
-        for (Pair<String, Object> logVar: getLogVariableList()) {
-            String label = logVar.first;
-            Object object = logVar.second;
-            switch(label) {
-                case "Cmdline":
-                    if (label != null) markdownString.append("\n").append(MarkdownUtils.getMultiLineMarkdownStringEntry(label, object, "-"));
-                    break;
-                default:
-                    markdownString.append("\n").append(MarkdownUtils.getSingleLineMarkdownStringEntry(label, object, "-"));
-            }
-        }
-
-        return markdownString.toString();
+    public void appendMarkdownHeader(StringBuilder markdownString) {
+        markdownString.append("Peer Cred:");
     }
+
+    @Override
+    public boolean isMarkdownMultiLine(String label) {
+        return label.equals("Cmdline");
+    }
+
+    @Override
+    public void appendMarkdownFooter(StringBuilder markdownString) {
+    }
+
 }

--- a/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/PeerCredStringGenerator.java
+++ b/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/PeerCredStringGenerator.java
@@ -8,26 +8,18 @@ import com.termux.shared.markdown.MarkdownUtils;
 import java.util.List;
 
 public class PeerCredStringGenerator extends StringGenerator{
+    @Override
+    public void appendLogHeader(StringBuilder logString) {
+        logString.append("Peer Cred:");
+    }
 
     @Override
-    public String getLogString() {
-        StringBuilder logString = new StringBuilder();
+    public boolean isLogMultiLine(String label) {
+        return label.equals("Cmdline");
+    }
 
-        logString.append("Peer Cred:");
-
-        for (Pair<String, Object> logVar: getLogVariableList()) {
-            String label = logVar.first;
-            Object object = logVar.second;
-            switch(label) {
-                case "Cmdline":
-                    if (label != null) logString.append("\n").append(Logger.getMultiLineLogStringEntry(label, object, "-"));
-                    break;
-                default:
-                    logString.append("\n").append(Logger.getSingleLineLogStringEntry(label, object, "-"));
-            }
-        }
-
-        return logString.toString();
+    @Override
+    public void appendLogFooter(StringBuilder logString) {
     }
 
     @Override

--- a/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/PeerCredStringGenerator.java
+++ b/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/PeerCredStringGenerator.java
@@ -1,12 +1,5 @@
 package com.termux.shared.net.socket.local.StringGenerator;
 
-import android.util.Pair;
-
-import com.termux.shared.logger.Logger;
-import com.termux.shared.markdown.MarkdownUtils;
-
-import java.util.List;
-
 public class PeerCredStringGenerator extends StringGenerator{
     @Override
     public void appendLogHeader(StringBuilder logString) {

--- a/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/StringGenerator.java
+++ b/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/StringGenerator.java
@@ -2,6 +2,8 @@ package com.termux.shared.net.socket.local.StringGenerator;
 
 import android.util.Pair;
 
+import com.termux.shared.logger.Logger;
+
 import java.util.List;
 
 // Singleton 적용하기
@@ -10,12 +12,36 @@ public abstract class StringGenerator {
 
     public void setLogVariableList(List<Pair<String, Object>> logVariableList) {
         this.logVariableList = logVariableList;
-    };
+    }
 
     public List<Pair<String, Object>> getLogVariableList() {
         return logVariableList;
-    };
+    }
 
-    public abstract String getLogString();
+    public String getLogString() {
+        StringBuilder logString = new StringBuilder();
+
+        appendLogHeader(logString);
+
+        for(Pair<String, Object> logVar: getLogVariableList()) {
+            String label = logVar.first;
+            Object object = logVar.second;
+            if (isLogMultiLine(label))
+                logString.append("\n").append(Logger.getMultiLineLogStringEntry(label, object, "-"));
+            else
+                logString.append("\n").append(Logger.getSingleLineLogStringEntry(label, object, "-"));
+        }
+
+        appendLogFooter(logString);
+
+        return logString.toString();
+    }
+
+    public abstract void appendLogHeader(StringBuilder logString);
+    public abstract boolean isLogMultiLine(String label);
+    public abstract void appendLogFooter(StringBuilder logString);
+
     public abstract String getMarkdownString();
+
+
 }

--- a/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/StringGenerator.java
+++ b/termux-shared/src/main/java/com/termux/shared/net/socket/local/StringGenerator/StringGenerator.java
@@ -3,6 +3,7 @@ package com.termux.shared.net.socket.local.StringGenerator;
 import android.util.Pair;
 
 import com.termux.shared.logger.Logger;
+import com.termux.shared.markdown.MarkdownUtils;
 
 import java.util.List;
 
@@ -41,7 +42,27 @@ public abstract class StringGenerator {
     public abstract boolean isLogMultiLine(String label);
     public abstract void appendLogFooter(StringBuilder logString);
 
-    public abstract String getMarkdownString();
+    public String getMarkdownString() {
+        StringBuilder markdownString = new StringBuilder();
 
+        appendMarkdownHeader(markdownString);
+
+        for (Pair<String, Object> logVar: getLogVariableList()) {
+            String label = logVar.first;
+            Object object = logVar.second;
+            if (isMarkdownMultiLine(label))
+                markdownString.append("\n").append(MarkdownUtils.getMultiLineMarkdownStringEntry(label, object, "-"));
+            else
+                markdownString.append("\n").append(MarkdownUtils.getSingleLineMarkdownStringEntry(label, object, "-"));
+        }
+
+        appendMarkdownFooter(markdownString);
+
+        return markdownString.toString();
+    }
+
+    public abstract void appendMarkdownHeader(StringBuilder logString);
+    public abstract boolean isMarkdownMultiLine(String label);
+    public abstract void appendMarkdownFooter(StringBuilder logString);
 
 }


### PR DESCRIPTION
Apply Template pattern in `StringGenerator`.
The classes extending `StringGenerator` has same form each other in `getLogString()` and `getMarkdownString()`, so applied Template pattern for standardizing logging and markdown string.