### PR TITLE
Test `UrlUtils`, `UriUtils`

### DIFF
--- a/termux-shared/src/androidTest/java/com/termux/shared/net/uri/UriUtilsTest.java
+++ b/termux-shared/src/androidTest/java/com/termux/shared/net/uri/UriUtilsTest.java
@@ -39,4 +39,17 @@ public class UriUtilsTest {
         assertEquals("/path1/path2#fragment", UriUtils.getUriFilePathWithFragment(uriWithParse), UriUtils.getUriFilePathWithFragment(uriWithBuilder));
     }
 
+    /**
+     * Purpose: Check the each Uri made by {@link Uri#parse(String)} and {@link UriUtils#getFileUri(String)}
+     * Input: Uri.parse("file:///path1/path2#fragment"), UriUtils.getFileUri("/path1/path2#fragment")
+     * Expected: "path2#fragment"
+     */
+    @Test
+    public void testGetUriFileBasenameUriWithFragment() {
+        Uri uriWithParse = Uri.parse("file:///path1/path2#fragment");
+        Uri uriWithBuilder = UriUtils.getFileUri("/path1/path2#fragment");
+        assertEquals("path2#fragment", UriUtils.getUriFileBasename(uriWithParse, true));
+        assertEquals("path2#fragment", UriUtils.getUriFileBasename(uriWithBuilder, true));
+    }
+
 }

--- a/termux-shared/src/androidTest/java/com/termux/shared/net/uri/UriUtilsTest.java
+++ b/termux-shared/src/androidTest/java/com/termux/shared/net/uri/UriUtilsTest.java
@@ -27,4 +27,16 @@ public class UriUtilsTest {
         assertNull(UriUtils.getUriFilePathWithFragment(nullPathUri));
     }
 
+    /**
+     * Purpose: Check the each Uri made by {@link Uri#parse(String)} and {@link UriUtils#getFileUri(String)}
+     * Input: Uri.parse("file:///path1/path2#fragment"), UriUtils.getFileUri("/path1/path2#fragment")
+     * Expected: "/path1/path2#fragment"
+     */
+    @Test
+    public void testGetUriFilePath() {
+        Uri uriWithParse = Uri.parse("file:///path1/path2#fragment");
+        Uri uriWithBuilder = UriUtils.getFileUri("/path1/path2#fragment");
+        assertEquals("/path1/path2#fragment", UriUtils.getUriFilePathWithFragment(uriWithParse), UriUtils.getUriFilePathWithFragment(uriWithBuilder));
+    }
+
 }

--- a/termux-shared/src/androidTest/java/com/termux/shared/net/uri/UriUtilsTest.java
+++ b/termux-shared/src/androidTest/java/com/termux/shared/net/uri/UriUtilsTest.java
@@ -1,0 +1,30 @@
+package com.termux.shared.net.uri;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+import android.net.Uri;
+
+@RunWith(AndroidJUnit4.class)
+public class UriUtilsTest {
+    /**
+     * Purpose: Check the null, empty or null path url string
+     * Input: null, "", "file://"
+     * Expected: null
+     */
+    @Test
+    public void testGetUriFilePathWithFragmentNull() {
+        assertNull(UriUtils.getUriFilePathWithFragment(null));
+
+        Uri nullUri = Uri.parse("");
+        assertNull(UriUtils.getUriFilePathWithFragment(nullUri));
+
+        Uri nullPathUri = Uri.parse("file://");
+        assertNull(UriUtils.getUriFilePathWithFragment(nullPathUri));
+    }
+
+}

--- a/termux-shared/src/androidTest/java/com/termux/shared/net/uri/UriUtilsTest.java
+++ b/termux-shared/src/androidTest/java/com/termux/shared/net/uri/UriUtilsTest.java
@@ -52,4 +52,17 @@ public class UriUtilsTest {
         assertEquals("path2#fragment", UriUtils.getUriFileBasename(uriWithBuilder, true));
     }
 
+    /**
+     * Purpose: Check the each Uri made by {@link Uri#parse(String)} and {@link UriUtils#getFileUri(String)}
+     * Input: Uri.parse("file:///path1/path2#fragment"), UriUtils.getFileUri("/path1/path2#fragment")
+     * Expected: "path2"
+     */
+    @Test
+    public void testGetUriFileBasenameUriOnlyPath() {
+        Uri uriWithParse = Uri.parse("file:///path1/path2#fragment");
+        Uri uriWithBuilder = UriUtils.getFileUri("/path1/path2#fragment");
+        assertEquals("path2", UriUtils.getUriFileBasename(uriWithParse, false));
+        assertEquals("path2", UriUtils.getUriFileBasename(uriWithBuilder, false));
+    }
+
 }

--- a/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
+++ b/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
@@ -36,4 +36,14 @@ public class UrlUtilsTest extends TestCase {
         assertNull(UrlUtils.joinUrl(base, destination, false));
     }
 
+    /**
+     * Purpose: Check the empty or null url string
+     * Input: "", null
+     * Expected: null
+     */
+    public void testGetUrlEmptyOrNull() {
+        assertNull(UrlUtils.getUrl(""));
+        assertNull(UrlUtils.getUrl(null));
+    }
+
 }

--- a/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
+++ b/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
@@ -14,4 +14,15 @@ public class UrlUtilsTest extends TestCase {
         assertEquals(base + "/" + destination, UrlUtils.joinUrl(base, destination, false));
     }
 
+    /**
+     * Purpose: Check the wrong form
+     * Input: base: "github.com", destination: "termux/termux-app"
+     * Expected: null
+     */
+    public void testJoinUrlWrongForm() {
+        String base = "github.com";
+        String destination = "termux/termux-app";
+        assertNull(UrlUtils.joinUrl(base, destination, false));
+    }
+
 }

--- a/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
+++ b/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
@@ -60,4 +60,44 @@ public class UrlUtilsTest extends TestCase {
         assertEquals(result.toString(), url);
     }
 
+    /**
+     * Purpose: Check URI generic syntax
+     * Input: "https://username:password@host:1234/path1/path2?query1=1&query2=2#fragment"
+     * Expected:
+     *      protocol        https
+     *      user_info       username:password
+     *      host            host
+     *      port            1234
+     *      authority       username:password@host:1234
+     *      path            /path1/path2
+     *      query           query1=1&query2=2
+     *      file            /path1/path2?query1=1&query2=2
+     *      fragment, ref   fragment
+     * https://en.wikipedia.org/wiki/URL
+     */
+    public void testGetUrlPart() {
+        String genericURI = "https://username:password@host:1234/path1/path2?query1=1&query2=2#fragment";
+
+        String protocol = UrlUtils.getUrlPart(genericURI, UrlUtils.UrlPart.PROTOCOL);
+        String user_info = UrlUtils.getUrlPart(genericURI, UrlUtils.UrlPart.USER_INFO);
+        String host = UrlUtils.getUrlPart(genericURI, UrlUtils.UrlPart.HOST);
+        String port = UrlUtils.getUrlPart(genericURI, UrlUtils.UrlPart.PORT);
+        String authority = UrlUtils.getUrlPart(genericURI, UrlUtils.UrlPart.AUTHORITY);
+        String path = UrlUtils.getUrlPart(genericURI, UrlUtils.UrlPart.PATH);
+        String query = UrlUtils.getUrlPart(genericURI, UrlUtils.UrlPart.QUERY);
+        String file = UrlUtils.getUrlPart(genericURI, UrlUtils.UrlPart.FILE);
+        String ref = UrlUtils.getUrlPart(genericURI, UrlUtils.UrlPart.REF);
+        String fragment = UrlUtils.getUrlPart(genericURI, UrlUtils.UrlPart.FRAGMENT);
+
+        assertEquals(protocol, "https");
+        assertEquals(user_info, "username:password");
+        assertEquals(host, "host");
+        assertEquals(port, "1234");
+        assertEquals(user_info + "@" + host + ":" + port, authority);
+        assertEquals(path, "/path1/path2");
+        assertEquals(query, "query1=1&query2=2");
+        assertEquals(path + "?" + query, file);
+        assertEquals(fragment, ref, "fragment");
+    }
+
 }

--- a/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
+++ b/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
@@ -150,4 +150,25 @@ public class UrlUtilsTest extends TestCase {
         assertFalse(UrlUtils.areUrlsEqual(null, ""));
     }
 
+    /**
+     * Purpose: Case when same url with different way of expression
+     * Input: ("http://github.com",     "https://github.com")
+     *        ("https://github.com",    "https://github.com/")
+     *        ("github.com",            "https://www.github.com/")
+     * Expected: true
+     */
+    public void testAreUrlsEqual() {
+        String httpUrl = "http://github.com";
+        String httpsUrl = "https://github.com";
+        assertTrue(UrlUtils.areUrlsEqual(httpUrl, httpsUrl));
+
+        String noSlashUrl = "https://github.com";
+        String slashUrl = "https://github.com/";
+        assertTrue(UrlUtils.areUrlsEqual(noSlashUrl, slashUrl));
+
+        String pureUrl = "github.com";
+        String wwwUrl = "https://www.github.com/";
+        assertTrue(UrlUtils.areUrlsEqual(pureUrl, wwwUrl));
+    }
+
 }

--- a/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
+++ b/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
@@ -25,4 +25,15 @@ public class UrlUtilsTest extends TestCase {
         assertNull(UrlUtils.joinUrl(base, destination, false));
     }
 
+    /**
+     * Purpose: Check the unknown protocol
+     * Input: base: "unknownProtocol://github.com", destination: "termux/termux-app"
+     * Expected: null
+     */
+    public void testJoinUrlUnknownProtocol() {
+        String base = "unknownProtocol://github.com";
+        String destination = "termux/termux-app";
+        assertNull(UrlUtils.joinUrl(base, destination, false));
+    }
+
 }

--- a/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
+++ b/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
@@ -100,4 +100,41 @@ public class UrlUtilsTest extends TestCase {
         assertEquals(fragment, ref, "fragment");
     }
 
+    /**
+     * Purpose: Check the url with some missing parts
+     * Input: "http://[1111:1111:1:2::4]/imgDir/someImg.png"
+     * Expected:
+     *      protocol        http
+     *      user_info       null
+     *      host            [1111:1111:1:2::4]
+     *      port            -1
+     *      authority       [1111:1111:1:2::4]
+     *      path            /imgDir/someImg.png
+     *      query           null
+     *      file            /imgDir/someImg.png
+     *      fragment, ref   null
+     */
+    public void testGetUrlPartMissingParts() {
+        String someUrl = "http://[1111:1111:1:2::4]/imgDir/someImg.png";
+
+        String protocol = UrlUtils.getUrlPart(someUrl, UrlUtils.UrlPart.PROTOCOL);
+        String user_info = UrlUtils.getUrlPart(someUrl, UrlUtils.UrlPart.USER_INFO);
+        String host = UrlUtils.getUrlPart(someUrl, UrlUtils.UrlPart.HOST);
+        String port = UrlUtils.getUrlPart(someUrl, UrlUtils.UrlPart.PORT);
+        String authority = UrlUtils.getUrlPart(someUrl, UrlUtils.UrlPart.AUTHORITY);
+        String path = UrlUtils.getUrlPart(someUrl, UrlUtils.UrlPart.PATH);
+        String query = UrlUtils.getUrlPart(someUrl, UrlUtils.UrlPart.QUERY);
+        String file = UrlUtils.getUrlPart(someUrl, UrlUtils.UrlPart.FILE);
+        String ref = UrlUtils.getUrlPart(someUrl, UrlUtils.UrlPart.REF);
+        String fragment = UrlUtils.getUrlPart(someUrl, UrlUtils.UrlPart.FRAGMENT);
+
+        assertEquals(protocol, "http");
+        assertNull(user_info);
+        assertEquals(host, authority, "[1111:1111:1:2::4]");
+        assertEquals(port, "-1");
+        assertEquals(path, file, "/imgDir/someImg.png");
+        assertNull(query);
+        assertNull(fragment, ref);
+    }
+
 }

--- a/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
+++ b/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
@@ -2,6 +2,8 @@ package com.termux.shared.net.url;
 
 import junit.framework.TestCase;
 
+import java.net.URL;
+
 public class UrlUtilsTest extends TestCase {
     /**
      * Purpose: Check the right form(success)
@@ -44,6 +46,18 @@ public class UrlUtilsTest extends TestCase {
     public void testGetUrlEmptyOrNull() {
         assertNull(UrlUtils.getUrl(""));
         assertNull(UrlUtils.getUrl(null));
+    }
+
+    /**
+     * Purpose: Check the right form(success)
+     * Input: "https://github.com"
+     * Expected: URL("https://github.com")
+     */
+    public void testGetUrl() {
+        String url = "https://github.com";
+        URL result = UrlUtils.getUrl(url);
+        assertNotNull(result);
+        assertEquals(result.toString(), url);
     }
 
 }

--- a/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
+++ b/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
@@ -1,0 +1,17 @@
+package com.termux.shared.net.url;
+
+import junit.framework.TestCase;
+
+public class UrlUtilsTest extends TestCase {
+    /**
+     * Purpose: Check the right form(success)
+     * Input: base: "https://github.com", destination: "termux/termux-app"
+     * Expected: "https://github.com/termux/termux-app"
+     */
+    public void testJoinUrlRight() {
+        String base = "https://github.com";
+        String destination = "termux/termux-app";
+        assertEquals(base + "/" + destination, UrlUtils.joinUrl(base, destination, false));
+    }
+
+}

--- a/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
+++ b/termux-shared/src/test/java/com/termux/shared/net/url/UrlUtilsTest.java
@@ -137,4 +137,17 @@ public class UrlUtilsTest extends TestCase {
         assertNull(fragment, ref);
     }
 
+    /**
+     * Purpose: Case when urls are empty or null
+     * Input: ("", ""), (null, null), (null, "")
+     * Expected:
+     *      ("", ""), (null, null): true
+     *      (null, "")            : false
+     */
+    public void testAreUrlsEqualEmptyOrNull() {
+        assertTrue(UrlUtils.areUrlsEqual("", ""));
+        assertTrue(UrlUtils.areUrlsEqual(null, null));
+        assertFalse(UrlUtils.areUrlsEqual(null, ""));
+    }
+
 }


### PR DESCRIPTION
Added unit tests for `UrlUtils` and `UriUtils`.
Test case testGetUriFileBasenameUriOnlyPath() fails.